### PR TITLE
feat(theme): add light/dark theme toggle with system default and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var theme = (stored === 'dark' || stored === 'light')
+            ? stored
+            : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {
+          // ignore
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/Components/NavbarComponent/Navbar.css
+++ b/src/Components/NavbarComponent/Navbar.css
@@ -3,9 +3,9 @@
     width: 100%;
     justify-content: space-between;
     margin-top: 40px;
-    background-color: black;
-    color: white;
-    box-shadow: 0 3px 10px rgba(241, 47, 47, 0.8);
+    background-color: var(--fg);
+    color: var(--bg);
+    box-shadow: 0 3px 10px var(--accent);
     border-radius: 30px;
     padding: 20px 10px;
 }
@@ -27,7 +27,7 @@
 }
 
 .navbar-links-container a {
-    color: white;
+    color: var(--bg);
     text-decoration: none;
     padding-bottom: 2px;
     border-bottom: 3px solid transparent;
@@ -35,4 +35,13 @@
 
 .navbar-links-container a:hover{
     border-bottom: 3px solid;
+}
+
+.theme-toggle{
+    background: transparent;
+    color: var(--bg);
+    border: 1px solid rgba(255,255,255,0.2);
+    padding: 4px 10px;
+    border-radius: 999px;
+    cursor: pointer;
 }

--- a/src/Components/NavbarComponent/Navbar.jsx
+++ b/src/Components/NavbarComponent/Navbar.jsx
@@ -1,8 +1,23 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom';
 import './Navbar.css'
 
 function Navbar() {
+  const [theme, setTheme] = React.useState(() => {
+    try {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') return stored;
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } catch { return 'light'; }
+  });
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try { localStorage.setItem('theme', theme); } catch {}
+  }, [theme]);
+
+  const nextLabel = useMemo(() => theme === 'dark' ? '☀️ Light' : '🌙 Dark', [theme]);
+
   return (
     <div className='navbar-container'>
 
@@ -14,6 +29,7 @@ function Navbar() {
             <Link to={'/'}>HOME</Link>
             <Link to={'/listings'}>LISTINGS</Link>
             <Link to={'/bookings'}>BOOKINGS</Link> 
+            <button aria-label="Toggle theme" className='theme-toggle' onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>{nextLabel}</button>
         </div>
         
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,23 @@
   font-family: Verdana, Geneva, Tahoma, sans-serif;
 }
 
-body{
-  background-color: rgba(128, 128, 128, 0.2);
+:root {
+  --bg: #ffffff;
+  --fg: #0f172a;
+  --muted: #334155;
+  --card: #f8fafc;
+  --accent: #ef4444; /* matches existing navbar shadow tone */
+}
+
+[data-theme="dark"] {
+  --bg: #0b0b10;
+  --fg: #e5e7eb;
+  --muted: #94a3b8;
+  --card: #111827;
+  --accent: #f87171;
+}
+
+html, body{
+  background: var(--bg);
+  color: var(--fg);
 }


### PR DESCRIPTION
**What**: Add light/dark theme using CSS variables, system preference on first load, navbar toggle, and localStorage persistence.
**Why**: Implements “Create Theme Changer”.
**Linked** issue: Closes #4
**Files changed:**
index.html (pre-load theme script)
src/index.css (theme variables)
src/Components/NavbarComponent/Navbar.jsx (toggle + state)
src/Components/NavbarComponent/Navbar.css (use variables)
**How to test:**
1) npm i && npm run dev
2) Use the navbar toggle to switch themes
3) Reload: theme persists
4) Set OS theme to dark: first load defaults to dark
**Notes**: Accessible toggle (aria-label), no breaking changes.
**Checklist**:
[x] Lints/compiles locally
[x] Tested light/dark and reload persistence
[x] Linked issue with “Closes #4”
